### PR TITLE
Build wheels in own container, mount from there

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM ubuntu
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
-RUN apt-get install --no-install-recommends -y python-pip
-# build.sh puts wheels for all the bayeslite dependencies into venv/wheelhouse.
-COPY venv/wheelhouse/* /usr/local/wheelhouse/
-RUN pip install /usr/local/wheelhouse/*.whl
+RUN apt-get install -y python-pip python-dev
+RUN pip install numpy cython
+# XXX: In my hands, building a wheel for crosscat directly does not work, but
+# preceeding wheel construction with an install does.
+RUN pip install crosscat
+RUN pip wheel --wheel-dir=wheelhouse bayeslite
+RUN pip install wheelhouse/bayeslite*.whl
+VOLUME ["/wheelhouse"]

--- a/README.md
+++ b/README.md
@@ -9,3 +9,22 @@ It is [served on Docker Hub](https://hub.docker.com/r/empiricalsys/ubuntubayesli
 `empiricalsys/ubuntubayeslite`.
 
 The current build status is at https://travis-ci.org/empiricalsys/ubuntubayeslite.
+
+## Build process
+
+Build by running `build.sh`.  It takes the following actions
+
+1. `docker build` builds an image `ubuntubayeslite-wheels` from the
+   `Dockerfile`. This image contains the wheels necessary to install bayeslite
+   in an externally mountable volumue, `/wheelhouse`.
+
+2. A "data container," `wheels-container` is initiated from
+   `ubuntubayeslite-wheels` so that `/wheelhouse` can be mounted from it.
+
+3. A new container, named `build-container`, is started from `ubuntu:latest`
+   with `/wheelhouse` mounted in it. The `install.sh` script is run in it. This
+   `apt-get` installs `pip`, then `pip install`s bayeslite from the wheels in
+   `/wheelhouse`.
+
+4. A new image, `empiricalsys/ubuntubayeslite` is commited from the
+   `build-container`.

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,17 @@
 #!/bin/sh -e
 
-rm -rf venv
-virtualenv venv
-
-./venv/bin/pip install numpy cython
-./venv/bin/pip wheel --wheel-dir=venv/wheelhouse bayeslite
-
-docker build -t empiricalsys/ubuntubayeslite .
+# Make sure we have the latest ubuntu:latest
+docker pull ubuntu
+docker build -t ubuntubayeslite-wheels .
+# Make a "wheels-container" from the image we just built, so we can mount it in
+# a "build-container" to finish the build . First remove containers with those
+# names, if they're hanging around from another build.
+docker rm wheels-container || /bin/true
+docker rm build-container || /bin/true
+docker run --name wheels-container ubuntubayeslite-wheels /bin/true
+# Now make another container from ubuntu:latest
+docker run -it --name build-container \
+       --volumes-from wheels-container \
+       -v `pwd`/install.sh:/install.sh \
+       ubuntu /install.sh
+docker commit build-container empiricalsys/ubuntubayeslite

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends python-pip
+pip install wheelhouse/*.whl
+apt-get clean
+rm -rf /var/lib/apt/lists


### PR DESCRIPTION
This has two benefits:

    1. The build process is much more independent of the build
       environment.

    2. The resulting image is 270M, down from a reported 330M

It probably helps the reduced size that I clean up the `apt-get` state
in the usual way.  I haven't measured how much.